### PR TITLE
Adds check for identifier

### DIFF
--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -107,7 +107,9 @@ export function modelCanRun(activity) {
       }
     }
   }
-  if (activityType === ACTIVITY_TYPE_PURCHASE && lineItems && lineItems.length) {
+  const hasLineItems = lineItems && lineItems.length > 0;
+  const hasIdentifiers = lineItems && lineItems.every(item => item.identifier);
+  if (activityType === ACTIVITY_TYPE_PURCHASE && hasLineItems && hasIdentifiers) {
     return true;
   }
 


### PR DESCRIPTION
## Issue

Resolves #465

## Description

Changes the Purchases `modelCanRun` function to check for `identifier` in `lineItems`. 

### FYI

This change will mean the co2engine package will throw many more `'No carbonModel available for this activity.'` errors. I don't think it has any implications, but would love some additional thoughts here :)