### PR TITLE
Added home and laptop icons

### DIFF
--- a/co2eq/purchase/footprints.yml
+++ b/co2eq/purchase/footprints.yml
@@ -5153,6 +5153,7 @@ _children:
         year: 2011
         unit: EUR
         source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        icon: home
         intensityKilograms:
           AT: 0.14087843881478576
           AU: 0.07724554347685257
@@ -6558,6 +6559,7 @@ _children:
     coicopCode: '08'
     year: 2011
     unit: EUR
+    icon: laptop
     source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
     intensityKilograms:
       AT: 0.16165337175967465


### PR DESCRIPTION
"Housing" and "Information & com'" didn't have any icons, as can be seen here:

![image](https://user-images.githubusercontent.com/1655848/97546335-980ddc00-19cc-11eb-87b8-0ddc091d7904.png)

I therefore added the home and laptop icons.