### PR TITLE
Skip loading env.json file

### DIFF
--- a/integrations/loadEnv.js
+++ b/integrations/loadEnv.js
@@ -1,4 +1,3 @@
-// eslint-disable-next-line import/no-unresolved
-import env from './env.json';
+const { env } = process;
 
 export default env;


### PR DESCRIPTION
Skip loading the env.json file, which we no longer use. Instead of removing the `loadEnv` completely, I updated it to use `process.env`.

Note that this is a blocker for migrating to TypeScript.