### PR TITLE
Publish bloom-contrib as an npm package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,25 +1,16 @@
-# Javascript Node CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-javascript/ for more details
-#
 version: 2
+
 jobs:
   lint_yml:
     docker:
       - image: circleci/python:3.7.4
-    working_directory: ~/repo
     steps:
       - checkout
       - run: pip install --user yamllint && yamllint co2eq/**/*.yml
 
-  build:
+  verify:
     docker:
-      # specify the version you desire here
       - image: circleci/node:10.13
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-    working_directory: ~/repo
     steps:
       - checkout
       # Download and cache dependencies
@@ -38,10 +29,31 @@ jobs:
       - run: yarn lint:bail
       - run: yarn test
       - run: yarn build
+      - persist_to_workspace:
+          root: .
+          paths:
+            - .
+
+  deploy:
+    docker:
+      - image: circleci/node:10.13
+    steps:
+      - attach_workspace:
+          at: .
+      - run: bash scripts/release.sh
+
 
 workflows:
   version: 2
-  lint_yml_and_build:
+  main_workflow:
     jobs:
       - lint_yml
-      - build
+      - verify
+      - deploy:
+          requires:
+            - lint_yml
+            - verify
+          filters:
+            branches:
+              only:
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,10 +35,9 @@ jobs:
             - node_modules
             - playground/node_modules
           key: v1-dependencies-{{ checksum "yarn.lock" }}-{{ checksum "playground/yarn.lock" }}
-      # run linter
       - run: yarn lint:bail
-      # run tests
       - run: yarn test
+      - run: yarn build
 
 workflows:
   version: 2

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,2 @@
 node_modules
+dist

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ playground/dist
 coverage
 *.log
 .idea/
+dist

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Welcome to the open-source repository for the carbon models and integrations use
 [Bloom](https://www.bloomclimate.com) is a SaaS that allow companies to become climate leaders, from calculating their climate impact to communicating about their climate efforts. It connects to as many data sources as possible to assess your carbon footprint and find mitigation opportunities.
 
 ## Tomorrow is hiring!
+
 Tomorrow, the organisation behind Bloom builds tech to empower organisations and individuals to understand and reduce their carbon footprint.
 
 We're often hiring great people to join our team in Copenhagen. Head over to [our jobs page](https://www.tmrow.com/jobs) if you want to help out!
@@ -20,16 +21,17 @@ We're often hiring great people to join our team in Copenhagen. Head over to [ou
 - `./definitions.js`: constant definitions
 
 ## How can I help?
+
 You can help by helping us find, add and improve our Life Cycle Assessment (LCA) data as well as our carbon models.
 
 ### Adding or updating Life Cycle Assessment / carbon footprint of purchases and activities
 
-Our current models and Life Cycle Assessments (LCAs) that we use are accessible [here](https://github.com/tmrowco/northapp-contrib/tree/master/co2eq). Feel free to suggest new sources or add your own LCAs.
+Our current models and Life Cycle Assessments (LCAs) that we use are accessible [here](https://github.com/tmrowco/bloom-contrib/tree/master/co2eq). Feel free to suggest new sources or add your own LCAs.
 
-If you want to add individual items or ingredients, this is done [here](https://github.com/tmrowco/northapp-contrib/blob/master/co2eq/purchase/footprints.yml). Ideally, the studies used should be as global as possible and it's even better if they're systemic reviews (multiple studies in one!).
+If you want to add individual items or ingredients, this is done [here](https://github.com/tmrowco/bloom-contrib/blob/master/co2eq/purchase/footprints.yml). Ideally, the studies used should be as global as possible and it's even better if they're systemic reviews (multiple studies in one!).
 
 We also have open-sourced how we calculate the monetary emission factors used to compute the carbon footprint of a transactions.
-This can be found [here](https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase). 
+This can be found [here](https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase).
 
 #### Structure of a carbon model
 
@@ -72,20 +74,20 @@ export const modelVersion = '0';
 
 must be incremented.
 
-
-
 ### Integrations
 
-Our community has built integrations, that gather activities from a 3rd party datasource. 
+Our community has built integrations, that gather activities from a 3rd party datasource.
 All of them are used in the North app. Some of them may be used in Bloom.
 
 Here is the list of current 3rd party integrations:
 Official integrations:
+
 - ✈️ Tripit
 - ⚡ Barry
 - 🚗 Tesla Cockpit
 
 Community-supported integrations:
+
 - ✈️ Ryanair (contributor:[lauvrenn](https://github.com/lauvrenn))
 - ✈️ Wizzair (contributor:[lauvrenn](https://github.com/lauvrenn))
 - 🚂 Rejsekort
@@ -100,7 +102,6 @@ Community-supported integrations:
 - 🚗 Automatic (contributor:[lauvrenn](https://github.com/lauvrenn))
 - 🚗 MinVolkswagen (contributor:[folkev0gn](https://github.com/folkev0gn))
 
-
 #### Coding or debugging an integration
 
 If you want to work on or debug an integration, you may be able to find integration suggestions and bugs in [the issues](https://github.com/tmrowco/bloom-contrib/issues).
@@ -108,7 +109,7 @@ If you want to work on or debug an integration, you may be able to find integrat
 To make it easy for anyone to help out, a development playground is available:
 
 First, run `yarn` to install dependencies at the root of the repository.
-Next from the `playground` folder, run  `yarn serve` to start the playground and point your browser to [localhost:8000](http://localhost:8000) to get started.
+Next from the `playground` folder, run `yarn serve` to start the playground and point your browser to [localhost:8000](http://localhost:8000) to get started.
 
 #### How to make an integration
 
@@ -138,6 +139,7 @@ As the methods are pure, and to avoid re-asking the user for credentials everyti
 Activities require a certain formatting:
 
 ##### Transportation activity formatting
+
 ```javascript
 {
   id, // a string that uniquely represents this activity
@@ -156,6 +158,7 @@ Activities require a certain formatting:
 ```
 
 ##### Lodging activity formatting
+
 ```javascript
 {
   id, // a string that uniquely represents this activity
@@ -172,6 +175,7 @@ Activities require a certain formatting:
 ```
 
 ##### Electricity consumption activity formatting
+
 ```javascript
 {
   id, // a string that uniquely represents this activity
@@ -186,6 +190,7 @@ Activities require a certain formatting:
 ```
 
 ##### Transaction activity formatting
+
 ```javascript
 {
   id, // a string that uniquely represents this activity
@@ -198,7 +203,9 @@ Activities require a certain formatting:
   bankIdentifier, // (required for integrations with banks) a string that uniquely represents the bank.
 }
 ```
+
 ##### Meal activity formatting
+
 ```javascript
 {
   id, // a string that uniquely represents this activity
@@ -238,8 +245,8 @@ export function evaluateEmail(subject, from, bodyAsHtml, sendDate) {
 ```
 
 > Note: if you are implementing an email integration don't forget to run `getActivitiesFromEmail` from `integration/digital/parsers/index` for each email discovered and return the activities found by the parser in addition to your email activities.
-> Note: if you are implementing an email integration you don't add any email activites for each email (digital footprint), only activities generated by the parsers will be added from the content found in emails. This is because it'd impact the performance of the application and it's been decided to disbale adding email activities at the moment. [More information](https://github.com/tmrowco/northapp-contrib/pull/401), the email emission factor is available [here](https://gist.github.com/baywet/38f21c202db5baf22a630ccbb7bae2ef).
+> Note: if you are implementing an email integration you don't add any email activites for each email (digital footprint), only activities generated by the parsers will be added from the content found in emails. This is because it'd impact the performance of the application and it's been decided to disbale adding email activities at the moment. [More information](https://github.com/tmrowco/bloom-contrib/pull/401), the email emission factor is available [here](https://gist.github.com/baywet/38f21c202db5baf22a630ccbb7bae2ef).
 
 ### Giving ideas, features requests or bugs
 
-Please [add an issue here](https://github.com/tmrowco/northapp-contrib/issues/new).
+Please [add an issue here](https://github.com/tmrowco/bloom-contrib/issues/new).

--- a/co2eq/flights/airports.js
+++ b/co2eq/flights/airports.js
@@ -1,0 +1,3 @@
+import airports from './airports.json';
+
+export { airports };

--- a/co2eq/flights/index.js
+++ b/co2eq/flights/index.js
@@ -1,7 +1,7 @@
 import { geoDistance } from 'd3-geo'; // todo - add d3-geo in package.json
 import { ACTIVITY_TYPE_TRANSPORTATION, TRANSPORTATION_MODE_PLANE } from '../../definitions';
 
-import airports from './airports.json';
+import { airports } from './airports';
 import { getActivityDurationHours } from '../utils';
 import loadfactors from './loadfactors.json';
 

--- a/co2eq/food/ingredients.js
+++ b/co2eq/food/ingredients.js
@@ -14,7 +14,7 @@ export const explanation = {
   links: [
     {
       label: 'Tomorrow footprint database',
-      href: 'https://github.com/tmrowco/northapp-contrib/blob/master/co2eq/purchase/footprints.yml',
+      href: 'https://github.com/tmrowco/bloom-contrib/blob/master/co2eq/purchase/footprints.yml',
     },
   ],
 };

--- a/co2eq/purchase/README.md
+++ b/co2eq/purchase/README.md
@@ -21,11 +21,11 @@ There are multiple EEMRIO databases. There is a good overview of the different o
 
 EXIOBASE 3 is the output of multiple European research projects. Its database covers 43 countries and 5 bigger regions, and 200 product or 163 industries. Currently, we use EXIOBASE 3.4, accessible [here](https://www.exiobase.eu/index.php/data-download/exiobase3mon/118-exiobase3-4-iot-2011-pxp).
 
-We used the pymrio package, built and maintained by one of researchers behind EXIOBASE, to calculate the carbon footprint of the consumption of a product in a country, using an iPython Notebook accessible [here](https://github.com/tmrowco/northapp-contrib/blob/master/co2eq/purchase/exiobase/io/carbon_footprint_scopes.ipynb). While EXIOBASE gives us great crude numbers, there are a couple of adjustments to be made to have useful numbers.
+We used the pymrio package, built and maintained by one of researchers behind EXIOBASE, to calculate the carbon footprint of the consumption of a product in a country, using an iPython Notebook accessible [here](https://github.com/tmrowco/bloom-contrib/blob/master/co2eq/purchase/exiobase/io/carbon_footprint_scopes.ipynb). While EXIOBASE gives us great crude numbers, there are a couple of adjustments to be made to have useful numbers.
 
 ### COICOP
 
-The EXIOBASE product category is great for carbon intensive products, for example, there are multiple coal related products. However, the way most companies and humans understand products is a bit different. We decided to use the Classification of Individual Consumption by Purpose (COICOP) taxonomy. Because it&#39;s a UN standard, using COICOP allows us to reuse the work of other researchers and provide a common language if someone wanted to help us. To translate EXIOBASE categories into COICOP categories, we relied on a concordance table shared by Richard Woods (one of the researchers behind EXIOBASE), which is accessible [here](https://github.com/tmrowco/northapp-contrib/blob/master/co2eq/purchase/exiobase/COICOP_EU_ini.csv). This is done [here](https://github.com/tmrowco/northapp-contrib/blob/master/co2eq/purchase/exiobase/prepare.py).
+The EXIOBASE product category is great for carbon intensive products, for example, there are multiple coal related products. However, the way most companies and humans understand products is a bit different. We decided to use the Classification of Individual Consumption by Purpose (COICOP) taxonomy. Because it&#39;s a UN standard, using COICOP allows us to reuse the work of other researchers and provide a common language if someone wanted to help us. To translate EXIOBASE categories into COICOP categories, we relied on a concordance table shared by Richard Woods (one of the researchers behind EXIOBASE), which is accessible [here](https://github.com/tmrowco/bloom-contrib/blob/master/co2eq/purchase/exiobase/COICOP_EU_ini.csv). This is done [here](https://github.com/tmrowco/bloom-contrib/blob/master/co2eq/purchase/exiobase/prepare.py).
 
 ### VAT, producer price and basic price
 
@@ -35,11 +35,11 @@ In many accounting systems removing VAT is already done, but this is something w
 
 ### Consumer Price Indices
 
-EXIOBASE is using 2011 numbers. While there have been efforts to now-cast the database to 2016, we couldn&#39;t find it at the product level (only at industry level). For this reason, we use consumer price indices at least at country level to make sure purchases are converted to 2011 prices. This is done [here](https://github.com/tmrowco/northapp-contrib/blob/master/co2eq/purchase/index.js) at country level and year level using this [data-](https://github.com/tmrowco/northapp-contrib/blob/master/co2eq/purchase/consumerpriceindices.yml) in the future we could do it more accurately at sector level (documented [here](https://github.com/tmrowco/northapp-contrib/issues/392)).
+EXIOBASE is using 2011 numbers. While there have been efforts to now-cast the database to 2016, we couldn&#39;t find it at the product level (only at industry level). For this reason, we use consumer price indices at least at country level to make sure purchases are converted to 2011 prices. This is done [here](https://github.com/tmrowco/bloom-contrib/blob/master/co2eq/purchase/index.js) at country level and year level using this [data-](https://github.com/tmrowco/bloom-contrib/blob/master/co2eq/purchase/consumerpriceindices.yml) in the future we could do it more accurately at sector level (documented [here](https://github.com/tmrowco/bloom-contrib/issues/392)).
 
 ### Exchange rate
 
-Finally, EXIOBASE uses euros, so any purchases done in other currencies will be converted to euros. This is done [here](https://github.com/tmrowco/northapp-contrib/blob/master/co2eq/purchase/index.js) using exchange rates [here](https://github.com/tmrowco/northapp-contrib/blob/master/co2eq/purchase/exchange_rates_2011.json).
+Finally, EXIOBASE uses euros, so any purchases done in other currencies will be converted to euros. This is done [here](https://github.com/tmrowco/bloom-contrib/blob/master/co2eq/purchase/index.js) using exchange rates [here](https://github.com/tmrowco/bloom-contrib/blob/master/co2eq/purchase/exchange_rates_2011.json).
 
 ### How our data could be improved:
 

--- a/co2eq/purchase/exiobase/prepare.py
+++ b/co2eq/purchase/exiobase/prepare.py
@@ -95,7 +95,7 @@ for (coicop_code, values_by_country) in COICOP_FOOTPRINTS.items():
     print(f"Found {coicop_code}. Updating..")
     entry['year'] = 2011
     entry['unit'] = 'EUR'
-    entry['source'] = 'https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase'
+    entry['source'] = 'https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase'
     entry['intensityKilograms'] = values_by_country
 
 to_remove_in_parenthesis = [

--- a/co2eq/purchase/footprints.js
+++ b/co2eq/purchase/footprints.js
@@ -1,0 +1,3 @@
+import footprints from './footprints.yml';
+
+export { footprints };

--- a/co2eq/purchase/footprints.yml
+++ b/co2eq/purchase/footprints.yml
@@ -62,7 +62,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_TRANSPORTATION_AUTOMOTIVE_PARTS
           - Automotive parts or accessories
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: 07.2.1
         year: 2011
@@ -123,7 +123,7 @@ _children:
           - PURCHASE_CATEGORY_TRANSPORTATION_AUTOMOTIVE_SERVICE
           - Automotive services
           - Parking lot
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: 07.2.3
         year: 2011
@@ -1468,7 +1468,7 @@ _children:
           - Bar or nightclub
           - Gambling
           - Cinema
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '09.4'
         year: 2011
@@ -1535,7 +1535,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_ENTERTAINMENT_CRUISE_LINES
           - Cruise
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '09.8'
         year: 2011
@@ -1599,7 +1599,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_ENTERTAINMENT_HOTEL
           - Hotel
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '11.2'
         year: 2011
@@ -1671,7 +1671,7 @@ _children:
           - PURCHASE_CATEGORY_ENTERTAINMENT_LIQUOR_STORE
           - Liquor Store
           - Liquor store
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '02.1'
         year: 2011
@@ -1732,7 +1732,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_ENTERTAINMENT_CIGAR_STORES
           - Tobacco store
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '02.3'
         year: 2011
@@ -3563,7 +3563,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_HEALTHCARE_DOCTOR
           - Doctor
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '06.2'
         year: 2011
@@ -3630,7 +3630,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_HEALTHCARE_PHARMARCY
           - Drug store or pharmacy
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '06.1'
         year: 2011
@@ -3699,7 +3699,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_FOOD_BAKERY
           - Bakery
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: 01.1.1
         year: 2011
@@ -3763,7 +3763,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_STORE_BARBER_BEAUTY
           - Barber or beauty shop
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '13.1'
         year: 2011
@@ -3828,7 +3828,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_STORE_BOOKS
           - Bookshop
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '09.7'
         year: 2011
@@ -3902,7 +3902,7 @@ _children:
           - PURCHASE_CATEGORY_STORE_CLOTHING
           - Clothing
           - Department store
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '03.1'
         year: 2011
@@ -3971,7 +3971,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_STORE_ELECTRONIC
           - Electronic store
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '08.1'
         year: 2011
@@ -4052,7 +4052,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_STORE_EQUIPMENT_FURNITURE
           - Equipment furniture
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: 05.1.1
         year: 2011
@@ -4129,7 +4129,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_FOOD_SUPERMARKET
           - Grocery store
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '01'
         year: 2011
@@ -4141,7 +4141,7 @@ _children:
                 coicopCode: 01.1.2
                 year: 2011
                 unit: EUR
-                source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+                source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
                 intensityKilograms:
                   AT: 0.6458596804033253
                   AU: 1.2200355970120131
@@ -4198,7 +4198,7 @@ _children:
                 coicopCode: 01.1.3
                 year: 2011
                 unit: EUR
-                source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+                source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
                 intensityKilograms:
                   AT: 0.6538071632591153
                   AU: 0.7151866436004488
@@ -4254,7 +4254,7 @@ _children:
                 coicopCode: 01.1.4
                 year: 2011
                 unit: EUR
-                source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+                source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
                 intensityKilograms:
                   AT: 0.7436543711534668
                   AU: 1.2798545299946813
@@ -4314,7 +4314,7 @@ _children:
                 coicopCode: 01.1.5
                 year: 2011
                 unit: EUR
-                source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+                source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
                 intensityKilograms:
                   AT: 0.6057337241594754
                   AU: 1.2909064223784799
@@ -4370,7 +4370,7 @@ _children:
                 coicopCode: 01.1.6
                 year: 2011
                 unit: EUR
-                source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+                source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
                 intensityKilograms:
                   AT: 0.19370289605367663
                   AU: 0.8611099568546641
@@ -4426,7 +4426,7 @@ _children:
                 coicopCode: 01.1.7
                 year: 2011
                 unit: EUR
-                source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+                source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
                 intensityKilograms:
                   AT: 0.19370289605367663
                   AU: 0.8611099568546641
@@ -4482,7 +4482,7 @@ _children:
                 coicopCode: 01.1.8
                 year: 2011
                 unit: EUR
-                source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+                source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
                 intensityKilograms:
                   AT: 0.6126820350688966
                   AU: 1.1273580389252886
@@ -4538,7 +4538,7 @@ _children:
                 coicopCode: 01.1.9
                 year: 2011
                 unit: EUR
-                source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+                source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
                 intensityKilograms:
                   AT: 0.5307511843417203
                   AU: 0.7578693364698058
@@ -4592,7 +4592,7 @@ _children:
                 displayName: Ready-made food and other food products n.e.c.
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.5407268278791255
               AU: 1.0117255705608155
@@ -4648,7 +4648,7 @@ _children:
             coicopCode: '01.2'
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.4732692141066177
               AU: 0.5982950629919985
@@ -4756,7 +4756,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_STORE_HARDWARE
           - Hardware
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '05.5'
         year: 2011
@@ -4826,7 +4826,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_STORE_HOUSE_FURNISHING
           - House furnishing
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: 05.1.1.4
         year: 2011
@@ -4892,7 +4892,7 @@ _children:
         oldKeys:
           - PURCHASE_CATEGORY_STORE_HOUSEHOLD_APPLIANCE
           - Household appliances
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '05.3'
         year: 2011
@@ -4970,7 +4970,7 @@ _children:
           - Lawn and garden store
           - Pet shop
           - Florist
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         unit: EUR
         coicopCode: '09.3'
         year: 2011
@@ -5079,7 +5079,7 @@ _children:
     oldKeys:
       - PURCHASE_CATEGORY_TRANSPORTATION_FUEL
       - Fuel
-    source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+    source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
     unit: EUR
     coicopCode: 07.2.2
     year: 2011
@@ -5090,7 +5090,7 @@ _children:
         coicopCode: '03.2'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.24090536171805382
           AU: 0.4184398004774378
@@ -5152,7 +5152,7 @@ _children:
         coicopCode: '04.1'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         icon: home
         intensityKilograms:
           AT: 0.14087843881478576
@@ -5214,7 +5214,7 @@ _children:
         coicopCode: '04.2'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.14087843881478576
           AU: 0.07724554347685257
@@ -5270,7 +5270,7 @@ _children:
         coicopCode: '04.3'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.38056491587650726
           AU: 0.31363569561974763
@@ -5336,7 +5336,7 @@ _children:
         coicopCode: '04.4'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.6924904836402103
           AU: 1.2765332668876004
@@ -5394,7 +5394,7 @@ _children:
             coicopCode: 04.5.1
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 1.4050013479316374
               AU: 7.695917305376748
@@ -5450,7 +5450,7 @@ _children:
             coicopCode: 04.5.2
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 3.7908293499585253
               AU: 12.866038513759591
@@ -5506,7 +5506,7 @@ _children:
             coicopCode: 04.5.3
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 1.2548419017767323
               AU: 0.8783021491431163
@@ -5562,7 +5562,7 @@ _children:
             coicopCode: 04.5.4
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 1.2599037475375774
               AU: 0.7912623205504323
@@ -5618,7 +5618,7 @@ _children:
             coicopCode: 04.5.5
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 6.807844457727781
               BE: 8.20457678931672
@@ -5679,7 +5679,7 @@ _children:
             coicopCode: 05.1.2
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.22812402805976995
               AU: 0.3649665078033194
@@ -5739,7 +5739,7 @@ _children:
         coicopCode: '05.2'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.29520755617955524
           AU: 0.34154449856580765
@@ -5807,7 +5807,7 @@ _children:
         coicopCode: '05.4'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.437999418642222
           AU: 1.1190644116807336
@@ -5868,7 +5868,7 @@ _children:
             coicopCode: 05.6.1
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.5775486189019716
               AU: 0.482957600141181
@@ -5932,7 +5932,7 @@ _children:
             coicopCode: 05.6.2
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.09816295861178499
               AU: 0.4104469659589552
@@ -6004,7 +6004,7 @@ _children:
         coicopCode: '06.3'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.19637013890293112
           AU: 0.1736482164120421
@@ -6068,7 +6068,7 @@ _children:
         coicopCode: '07.1'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.2929329824286619
           AU: 0.5078416503301589
@@ -6131,7 +6131,7 @@ _children:
             coicopCode: 07.2.4
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.16013877400743093
               AU: 0.24653367138483467
@@ -6196,7 +6196,7 @@ _children:
             coicopCode: 07.3.1
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.23689995526780824
               AU: 0.40189654374834216
@@ -6257,7 +6257,7 @@ _children:
             coicopCode: 07.3.2
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.14329582412825928
               AU: 0.1592667554464537
@@ -6322,7 +6322,7 @@ _children:
             coicopCode: 07.3.3
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 1.024562601907154
               AU: 1.3216460338378595
@@ -6381,7 +6381,7 @@ _children:
             coicopCode: 07.3.4
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.798184617532687
               AU: 3.5656213549229276
@@ -6441,7 +6441,7 @@ _children:
             coicopCode: 07.3.5
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.1374337367650893
               AU: 0.16397221933734732
@@ -6497,7 +6497,7 @@ _children:
             coicopCode: 07.3.6
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.35132482243943225
               AU: 0.5207236634397208
@@ -6562,7 +6562,7 @@ _children:
     year: 2011
     unit: EUR
     icon: laptop
-    source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+    source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
     intensityKilograms:
       AT: 0.16165337175967465
       AU: 0.22984525614642085
@@ -6647,7 +6647,7 @@ _children:
         coicopCode: '09.1'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.15698386401742823
           AU: 0.16442133740445947
@@ -6716,7 +6716,7 @@ _children:
         coicopCode: '11.1'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.197102755077923
           AU: 0.39451879179304816
@@ -6786,7 +6786,7 @@ _children:
         coicopCode: '12.1'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.20525212768727508
           AU: 0.20183341279967892
@@ -6842,7 +6842,7 @@ _children:
         coicopCode: '12.2'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.20208118120307086
           AU: 0.3274472459684225
@@ -6906,7 +6906,7 @@ _children:
             coicopCode: 13.2.1
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.02613830423837556
               AU: 0.7036380641575152
@@ -6962,7 +6962,7 @@ _children:
             coicopCode: 13.2.9
             year: 2011
             unit: EUR
-            source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+            source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
             intensityKilograms:
               AT: 0.13325050330509872
               AU: 0.0821196889822095
@@ -7019,7 +7019,7 @@ _children:
         coicopCode: '13.3'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.09741379607500217
           AU: 0.053609539335968265
@@ -7075,7 +7075,7 @@ _children:
         coicopCode: '13.9'
         year: 2011
         unit: EUR
-        source: https://github.com/tmrowco/northapp-contrib/tree/master/co2eq/purchase/exiobase
+        source: https://github.com/tmrowco/bloom-contrib/tree/master/co2eq/purchase/exiobase
         intensityKilograms:
           AT: 0.11736647849656673
           AU: 0.09097813536165757

--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -30,7 +30,7 @@ export const explanation = {
   links: [
     {
       label: 'Tomorrow footprint database',
-      href: 'https://github.com/tmrowco/northapp-contrib/blob/master/co2eq/purchase/footprints.yml',
+      href: 'https://github.com/tmrowco/bloom-contrib/blob/master/co2eq/purchase/footprints.yml',
     },
   ],
 };

--- a/co2eq/purchase/index.js
+++ b/co2eq/purchase/index.js
@@ -18,7 +18,7 @@ import {
 } from '../../definitions';
 import { getAvailableCurrencies } from '../../integrations/utils/currency/currency';
 import { getChecksum } from '../utils';
-import footprints from './footprints.yml';
+import { footprints } from './footprints';
 import consumerPriceIndex from './consumerpriceindices.yml';
 import exchangeRates2011 from './exchange_rates_2011.json';
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmrow/bloom-contrib",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Carbon models and integrations used at Tomorrow",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmrow/bloom-contrib",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Carbon models and integrations used at Tomorrow",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "xmldom": "^0.1.27"
   },
   "devDependencies": {
+    "@babel/cli": "^7.12.1",
     "@babel/core": "^7.2.2",
     "@babel/plugin-proposal-class-properties": "^7.5.5",
     "@babel/plugin-transform-runtime": "^7.6.2",
@@ -41,6 +42,7 @@
     "prettier": "^1.19.1"
   },
   "scripts": {
+    "build": "bash scripts/build.sh",
     "lint": "yarn lint:bail --fix --quiet",
     "lint:bail": "eslint *.js co2eq integrations playground",
     "test": "TZ='Europe/Copenhagen' jest --no-cache"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmrow/bloom-contrib",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Carbon models and integrations used at Tomorrow",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,15 @@
 {
   "name": "@tmrow/bloom-contrib",
-  "version": "1.0.0",
-  "main": "server.js",
+  "version": "0.0.3",
+  "description": "Carbon models and integrations used at Tomorrow",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tmrowco/bloom-contrib.git"
+  },
+  "bugs": {
+    "url": "https://github.com/tmrowco/bloom-contrib/issues"
+  },
   "dependencies": {
     "@ideditor/country-coder": "^3.2.0",
     "@microsoft/microsoft-graph-client": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@types/microsoft-graph": "^1.12.0",
     "babel-eslint": "^10.0.1",
     "babel-plugin-convert-to-json": "^0.1.0",
+    "copyfiles": "^2.4.0",
     "eslint": "^5.5.0",
     "eslint-config-airbnb": "^17.1.0",
     "eslint-config-prettier": "^6.10.0",

--- a/playground/frontend/src/components/console.js
+++ b/playground/frontend/src/components/console.js
@@ -19,7 +19,7 @@ function mapLevelToMethods(logLevel) {
 }
 
 /**
- * Converts server side logs (as defined: https://github.com/tmrowco/northapp-contrib/blob/master/playground/server/index.js#L71-L76) to internal console feed format
+ * Converts server side logs (as defined: https://github.com/tmrowco/bloom-contrib/blob/master/playground/server/index.js#L71-L76) to internal console feed format
  * @param {*} logs
  */
 function transformToConsoleFeedFormat(logs) {

--- a/playground/frontend/src/components/consoleheader.js
+++ b/playground/frontend/src/components/consoleheader.js
@@ -10,7 +10,7 @@ import {
 } from '@material-ui/core';
 import Icon from './icon';
 
-// As defined here: https://github.com/tmrowco/northapp-contrib/blob/master/playground/server/index.js#L77-L81
+// As defined here: https://github.com/tmrowco/bloom-contrib/blob/master/playground/server/index.js#L77-L81
 export const logLevels = new Set(['error', 'warn', 'debug']);
 
 export default function ConsoleHeader({

--- a/playground/package.json
+++ b/playground/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "northapp-contrib-playground-frontend",
+  "name": "bloom-contrib-playground-frontend",
   "dependencies": {
     "@babel/register": "^7.6.2",
     "@material-ui/core": "^4.4.3",

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -10,5 +10,5 @@ yarn --silent babel co2eq          ${BABEL_CONFIG} --out-dir ${DIST_FOLDER}/co2e
 yarn --silent babel integrations   ${BABEL_CONFIG} --out-dir ${DIST_FOLDER}/integrations
 yarn --silent babel definitions.js ${BABEL_CONFIG} --out-dir ${DIST_FOLDER}
 
-yarn --silent copyfiles co2eq/**/*.json ${DIST_FOLDER}
-yarn --silent copyfiles integrations/**/*.json ${DIST_FOLDER}
+yarn --silent copyfiles "co2eq/**/*.json" ${DIST_FOLDER}
+yarn --silent copyfiles "integrations/**/*.json" ${DIST_FOLDER}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+BABEL_CONFIG="--ignore=**/*.test.js"
+DIST_FOLDER="dist"
+
+rm -rf ${DIST_FOLDER}
+yarn --silent babel co2eq          ${BABEL_CONFIG} --out-dir ${DIST_FOLDER}/co2eq
+yarn --silent babel integrations   ${BABEL_CONFIG} --out-dir ${DIST_FOLDER}/integrations
+yarn --silent babel definitions.js ${BABEL_CONFIG} --out-dir ${DIST_FOLDER}

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -9,3 +9,6 @@ rm -rf ${DIST_FOLDER}
 yarn --silent babel co2eq          ${BABEL_CONFIG} --out-dir ${DIST_FOLDER}/co2eq
 yarn --silent babel integrations   ${BABEL_CONFIG} --out-dir ${DIST_FOLDER}/integrations
 yarn --silent babel definitions.js ${BABEL_CONFIG} --out-dir ${DIST_FOLDER}
+
+yarn --silent copyfiles co2eq/**/*.json ${DIST_FOLDER}
+yarn --silent copyfiles integrations/**/*.json ${DIST_FOLDER}

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Publish from dist folder to get cleaner imports
+cp package.json LICENSE.txt README.md dist/
+cd dist
+
+if [ -z "$NPM_TOKEN" ]; then
+  echo "Expected NPM_TOKEN to be defined"
+  exit 1
+fi
+
+echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
+
+# Bump the patch version number
+npm version patch
+
+echo "Deploying"
+npm publish --access public
+
+# Push new version commit and tags
+git push origin --tags

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,11 +2,6 @@
 
 set -euo pipefail
 
-if [ -z "$NPM_TOKEN" ]; then
-  echo "Expected NPM_TOKEN to be defined"
-  exit 1
-fi
-
 echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
 
 # Bump the patch version number

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -2,10 +2,6 @@
 
 set -euo pipefail
 
-# Publish from dist folder to get cleaner imports
-cp package.json LICENSE.txt README.md dist/
-cd dist
-
 if [ -z "$NPM_TOKEN" ]; then
   echo "Expected NPM_TOKEN to be defined"
   exit 1
@@ -15,6 +11,10 @@ echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/.npmrc
 
 # Bump the patch version number
 npm version patch
+
+# Publish from dist folder to get cleaner imports
+cp package.json LICENSE.txt README.md dist/
+cd dist
 
 echo "Deploying"
 npm publish --access public

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,23 @@
 # yarn lockfile v1
 
 
+"@babel/cli@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/cli/-/cli-7.12.1.tgz#e08a0b1cb6fcd4b9eb6a606ba5602c5c0fe24a0c"
+  integrity sha512-eRJREyrfAJ2r42Iaxe8h3v6yyj1wu9OyosaUHW6UImjGf9ahGL9nsFNh7OCopvtcPL8WnEo7tp78wrZaZ6vG9g==
+  dependencies:
+    commander "^4.0.1"
+    convert-source-map "^1.1.0"
+    fs-readdir-recursive "^1.1.0"
+    glob "^7.0.0"
+    lodash "^4.17.19"
+    make-dir "^2.1.0"
+    slash "^2.0.0"
+    source-map "^0.5.0"
+  optionalDependencies:
+    "@nicolo-ribaudo/chokidar-2" "^2.1.8"
+    chokidar "^3.4.0"
+
 "@babel/code-frame@^7.0.0", "@babel/code-frame@^7.5.5":
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.5.5.tgz#bc0782f6d69f7b7d49531219699b988f669a8f9d"
@@ -1013,6 +1030,13 @@
     "@babel/runtime" "^7.4.4"
     tslib "^1.9.3"
 
+"@nicolo-ribaudo/chokidar-2@^2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8.tgz#eef8d9b47e8dc589499f14d656e8d2dd978c3d14"
+  integrity sha512-FohwULwAebCUKi/akMFyGi7jfc7JXTeMHzKxuP3umRd9mK/2Y7/SMBSI2jX+YLopPXi+PF9l307NmpfxTdCegA==
+  dependencies:
+    chokidar "2.1.8"
+
 "@sinonjs/commons@^1.7.0":
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.7.1.tgz#da5fd19a5f71177a53778073978873964f49acf1"
@@ -1238,7 +1262,7 @@ anymatch@^2.0.0:
     micromatch "^3.1.4"
     normalize-path "^2.1.1"
 
-anymatch@^3.0.3:
+anymatch@^3.0.3, anymatch@~3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/anymatch/-/anymatch-3.1.1.tgz#c55ecf02185e2469259399310c173ce31233b142"
   integrity sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
@@ -1315,6 +1339,11 @@ ast-types-flow@0.0.7, ast-types-flow@^0.0.7:
 astral-regex@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-1.0.0.tgz#6c8c3fb827dd43ee3918f27b82782ab7658a6fd9"
+
+async-each@^1.0.1:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.3.tgz#b727dbf87d7651602f06f4d4ac387f47d91b0cbf"
+  integrity sha512-z/WhQ5FPySLdvREByI2vZiTWwCnF0moMJ1hK9YQwDTHKh6I7/uSckMetoRGb5UBZPC1z0jlw+n/XCgjeH7y1AQ==
 
 asynckit@^0.4.0:
   version "0.4.0"
@@ -1434,6 +1463,23 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+binary-extensions@^1.0.0:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-1.13.1.tgz#598afe54755b2868a5330d2aff9d4ebb53209b65"
+  integrity sha512-Un7MIEDdUC5gNpcGDV97op1Ywk748MpHcFTHoYs6qnj1Z3j7I53VG3nwZhKzoBZmbdRNnb6WRdFlwl7tSDuZGw==
+
+binary-extensions@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.1.0.tgz#30fa40c9e7fe07dbc895678cd287024dea241dd9"
+  integrity sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==
+
+bindings@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/bindings/-/bindings-1.5.0.tgz#10353c9e945334bc0511a6d90b38fbc7c9c504df"
+  integrity sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==
+  dependencies:
+    file-uri-to-path "1.0.0"
+
 brace-expansion@^1.1.7:
   version "1.1.11"
   resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.11.tgz#3c7fcbf529d87226f3d2f52b966ff5271eb441dd"
@@ -1441,7 +1487,7 @@ brace-expansion@^1.1.7:
     balanced-match "^1.0.0"
     concat-map "0.0.1"
 
-braces@^2.3.1:
+braces@^2.3.1, braces@^2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-2.3.2.tgz#5979fd3f14cd531565e5fa2df1abfff1dfaee729"
   integrity sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
@@ -1457,7 +1503,7 @@ braces@^2.3.1:
     split-string "^3.0.2"
     to-regex "^3.0.1"
 
-braces@^3.0.1:
+braces@^3.0.1, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1568,6 +1614,40 @@ chardet@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.7.0.tgz#90094849f0937f2eedc2425d0d28a9e5f0cbad9e"
 
+chokidar@2.1.8:
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-2.1.8.tgz#804b3a7b6a99358c3c5c61e71d8728f041cff917"
+  integrity sha512-ZmZUazfOzf0Nve7duiCKD23PFSCs4JPoYyccjUFF3aQkQadqBhfzhjkwBH2mNOG9cTBwhamM37EIsIkZw3nRgg==
+  dependencies:
+    anymatch "^2.0.0"
+    async-each "^1.0.1"
+    braces "^2.3.2"
+    glob-parent "^3.1.0"
+    inherits "^2.0.3"
+    is-binary-path "^1.0.0"
+    is-glob "^4.0.0"
+    normalize-path "^3.0.0"
+    path-is-absolute "^1.0.0"
+    readdirp "^2.2.1"
+    upath "^1.1.1"
+  optionalDependencies:
+    fsevents "^1.2.7"
+
+chokidar@^3.4.0:
+  version "3.4.3"
+  resolved "https://registry.yarnpkg.com/chokidar/-/chokidar-3.4.3.tgz#c1df38231448e45ca4ac588e6c79573ba6a57d5b"
+  integrity sha512-DtM3g7juCXQxFVSNPNByEC2+NImtBuxQQvWlHunpJIS5Ocr0lG306cC7FCi7cEA0fzmybPUIl4txBIobk1gGOQ==
+  dependencies:
+    anymatch "~3.1.1"
+    braces "~3.0.2"
+    glob-parent "~5.1.0"
+    is-binary-path "~2.1.0"
+    is-glob "~4.0.1"
+    normalize-path "~3.0.0"
+    readdirp "~3.5.0"
+  optionalDependencies:
+    fsevents "~2.1.2"
+
 ci-info@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-2.0.0.tgz#67a9e964be31a51e15e5010d58e6f12834002f46"
@@ -1652,6 +1732,11 @@ commander@^2.11.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
 
+commander@^4.0.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-4.1.1.tgz#9fd602bd936294e9e9ef46a3f4d6964044b18068"
+  integrity sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==
+
 component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -1697,7 +1782,7 @@ core-js-compat@^3.1.1:
     browserslist "^4.6.6"
     semver "^6.3.0"
 
-core-util-is@1.0.2:
+core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
@@ -2316,6 +2401,11 @@ file-entry-cache@^5.0.1:
   dependencies:
     flat-cache "^2.0.1"
 
+file-uri-to-path@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz#553a7b8446ff6f684359c445f1e37a05dacc33dd"
+  integrity sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==
+
 fill-range@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-4.0.0.tgz#d544811d428f98eb06a63dc402d2403c328c38f7"
@@ -2397,14 +2487,32 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
+fs-readdir-recursive@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz#e32fc030a2ccee44a6b5371308da54be0b397d27"
+  integrity sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==
+
 fs.realpath@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
+
+fsevents@^1.2.7:
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
+  integrity sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==
+  dependencies:
+    bindings "^1.5.0"
+    nan "^2.12.1"
 
 fsevents@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.2.tgz#4c0a1fb34bc68e543b4b82a9ec392bfbda840805"
   integrity sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==
+
+fsevents@~2.1.2:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.1.3.tgz#fb738703ae8d2f9fe900c33836ddebee8b97f23e"
+  integrity sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
 
 function-bind@^1.1.1:
   version "1.1.1"
@@ -2455,7 +2563,22 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-glob@^7.1.1, glob@^7.1.4, glob@^7.1.6:
+glob-parent@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-3.1.0.tgz#9e6af6299d8d3bd2bd40430832bd113df906c5ae"
+  integrity sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=
+  dependencies:
+    is-glob "^3.1.0"
+    path-dirname "^1.0.0"
+
+glob-parent@~5.1.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
+  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  dependencies:
+    is-glob "^4.0.1"
+
+glob@^7.0.0, glob@^7.1.1, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -2481,6 +2604,11 @@ glob@^7.1.2, glob@^7.1.3:
 globals@^11.1.0, globals@^11.7.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
+
+graceful-fs@^4.1.11:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
+  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
 graceful-fs@^4.1.2:
   version "4.2.2"
@@ -2629,7 +2757,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3:
+inherits@2, inherits@^2.0.3, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
 
@@ -2679,6 +2807,20 @@ is-accessor-descriptor@^1.0.0:
 is-arrayish@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
+
+is-binary-path@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-1.0.1.tgz#75f16642b480f187a711c814161fd3a4a7655898"
+  integrity sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=
+  dependencies:
+    binary-extensions "^1.0.0"
+
+is-binary-path@~2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-binary-path/-/is-binary-path-2.1.0.tgz#ea1f7f3b80f064236e83470f86c09c254fb45b09"
+  integrity sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==
+  dependencies:
+    binary-extensions "^2.0.0"
 
 is-buffer@^1.1.5:
   version "1.1.6"
@@ -2744,7 +2886,7 @@ is-extendable@^1.0.1:
   dependencies:
     is-plain-object "^2.0.4"
 
-is-extglob@^2.1.1:
+is-extglob@^2.1.0, is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
   integrity sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
@@ -2763,7 +2905,14 @@ is-generator-fn@^2.0.0:
   resolved "https://registry.yarnpkg.com/is-generator-fn/-/is-generator-fn-2.1.0.tgz#7d140adc389aaf3011a8f2a2a4cfa6faadffb118"
   integrity sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
 
-is-glob@^4.0.1:
+is-glob@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-3.1.0.tgz#7ba5ae24217804ac70707b96922567486cc3e84a"
+  integrity sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=
+  dependencies:
+    is-extglob "^2.1.0"
+
+is-glob@^4.0.0, is-glob@^4.0.1, is-glob@~4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/is-glob/-/is-glob-4.0.1.tgz#7567dbe9f2f5e2467bc77ab83c4a29482407a5dc"
   integrity sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
@@ -2830,7 +2979,7 @@ is-wsl@^2.1.1:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
   integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
-isarray@1.0.0, isarray@^1.0.0:
+isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
@@ -3454,6 +3603,11 @@ lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
 
+lodash@^4.17.19:
+  version "4.17.20"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
+  integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
 lolex@^5.0.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-5.1.2.tgz#953694d098ce7c07bc5ed6d0e42bc6c0c6d5a367"
@@ -3466,6 +3620,14 @@ loose-envify@^1.0.0, loose-envify@^1.4.0:
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
+
+make-dir@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
+  integrity sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==
+  dependencies:
+    pify "^4.0.1"
+    semver "^5.6.0"
 
 make-dir@^3.0.0:
   version "3.0.2"
@@ -3502,7 +3664,7 @@ methods@^1.1.1:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
 
-micromatch@^3.1.4:
+micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-3.1.10.tgz#70859bc95c9840952f359a068a3fc49f9ecfac23"
   integrity sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
@@ -3613,6 +3775,11 @@ mute-stream@0.0.7:
   version "0.0.7"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
+nan@^2.12.1:
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -3681,7 +3848,7 @@ normalize-path@^2.1.1:
   dependencies:
     remove-trailing-separator "^1.0.1"
 
-normalize-path@^3.0.0:
+normalize-path@^3.0.0, normalize-path@~3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/normalize-path/-/normalize-path-3.0.0.tgz#0dcd69ff23a1c9b11fd0978316644a0388216a65"
   integrity sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
@@ -3903,6 +4070,11 @@ pascalcase@^0.1.1:
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
 
+path-dirname@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/path-dirname/-/path-dirname-1.0.2.tgz#cc33d24d525e099a5388c0336c6e32b9160609e0"
+  integrity sha1-zDPSTVJeCZpTiMAzbG4yuRYGCeA=
+
 path-exists@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/path-exists/-/path-exists-3.0.0.tgz#ce0ebeaa5f78cb18925ea7d810d7b59b010fd515"
@@ -3944,7 +4116,7 @@ performance-now@^2.1.0:
   resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
   integrity sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
 
-picomatch@^2.0.4, picomatch@^2.0.5:
+picomatch@^2.0.4, picomatch@^2.0.5, picomatch@^2.2.1:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.2.2.tgz#21f333e9b6b8eaff02468f5146ea406d345f4dad"
   integrity sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
@@ -3952,6 +4124,11 @@ picomatch@^2.0.4, picomatch@^2.0.5:
 pify@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
+
+pify@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/pify/-/pify-4.0.1.tgz#4b2cd25c50d598735c50292224fd8c6df41e3231"
+  integrity sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==
 
 pirates@^4.0.1:
   version "4.0.1"
@@ -4022,6 +4199,11 @@ pretty-format@^25.2.3:
 private@^0.1.6:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
+
+process-nextick-args@~2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/process-nextick-args/-/process-nextick-args-2.0.1.tgz#7820d9b16120cc55ca9ae7792680ae7dba6d7fe2"
+  integrity sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
 
 progress@^2.0.0:
   version "2.0.3"
@@ -4105,6 +4287,19 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
+readable-stream@^2.0.2:
+  version "2.3.7"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
+  integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.3"
+    isarray "~1.0.0"
+    process-nextick-args "~2.0.0"
+    safe-buffer "~5.1.1"
+    string_decoder "~1.1.1"
+    util-deprecate "~1.0.1"
+
 readable-stream@^3.0.6:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.4.0.tgz#a51c26754658e0a3c21dbf59163bd45ba6f447fc"
@@ -4112,6 +4307,22 @@ readable-stream@^3.0.6:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readdirp@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-2.2.1.tgz#0e87622a3325aa33e892285caf8b4e846529a525"
+  integrity sha512-1JU/8q+VgFZyxwrJ+SVIOsh+KywWGpds3NTqikiKpDMZWScmAYyKIgqkO+ARvNWJfXeXR1zxz7aHF4u4CyH6vQ==
+  dependencies:
+    graceful-fs "^4.1.11"
+    micromatch "^3.1.10"
+    readable-stream "^2.0.2"
+
+readdirp@~3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/readdirp/-/readdirp-3.5.0.tgz#9ba74c019b15d365278d2e91bb8c48d7b4d42c9e"
+  integrity sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==
+  dependencies:
+    picomatch "^2.2.1"
 
 realpath-native@^2.0.0:
   version "2.0.0"
@@ -4340,7 +4551,7 @@ safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.2.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
 
-safe-buffer@~5.1.1:
+safe-buffer@~5.1.0, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
 
@@ -4377,9 +4588,10 @@ saxes@^3.1.9:
   dependencies:
     xmlchars "^2.1.1"
 
-"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1:
+"semver@2 || 3 || 4 || 5", semver@^5.3.0, semver@^5.4.1, semver@^5.5.0, semver@^5.5.1, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
+  integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
 semver@^6.0.0, semver@^6.3.0:
   version "6.3.0"
@@ -4440,6 +4652,11 @@ sisteransi@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slash@^3.0.0:
   version "3.0.0"
@@ -4639,6 +4856,13 @@ string_decoder@^1.1.1:
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
   dependencies:
     safe-buffer "~5.2.0"
+
+string_decoder@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
+  integrity sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+  dependencies:
+    safe-buffer "~5.1.0"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
@@ -4930,6 +5154,11 @@ unset-value@^1.0.0:
     has-value "^0.3.1"
     isobject "^3.0.0"
 
+upath@^1.1.1:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/upath/-/upath-1.2.0.tgz#8f66dbcd55a883acdae4408af8b035a5044c1894"
+  integrity sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg==
+
 uri-js@^4.2.2:
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
@@ -4946,7 +5175,7 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
-util-deprecate@^1.0.1:
+util-deprecate@^1.0.1, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1775,6 +1775,19 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copyfiles@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/copyfiles/-/copyfiles-2.4.0.tgz#fcac72a4f2b882f021dd156b4bcf6d71315487bd"
+  integrity sha512-yGjpR3yjQdxccW8EcJ4a7ZCA6wGER6/Q2Y+b7bXbVxGeSHBf93i9d7MzTsx+VV1CpMKQa3v4ThZfXBcltMzl0w==
+  dependencies:
+    glob "^7.0.5"
+    minimatch "^3.0.3"
+    mkdirp "^1.0.4"
+    noms "0.0.0"
+    through2 "^2.0.1"
+    untildify "^4.0.0"
+    yargs "^15.3.1"
+
 core-js-compat@^3.1.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.2.1.tgz#0cbdbc2e386e8e00d3b85dc81c848effec5b8150"
@@ -2578,7 +2591,7 @@ glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.0.0, glob@^7.1.1, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.0, glob@^7.0.5, glob@^7.1.1, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -2757,7 +2770,7 @@ inflight@^1.0.4:
     once "^1.3.0"
     wrappy "1"
 
-inherits@2, inherits@^2.0.3, inherits@~2.0.3:
+inherits@2, inherits@^2.0.1, inherits@^2.0.3, inherits@~2.0.1, inherits@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
 
@@ -2978,6 +2991,11 @@ is-wsl@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
   integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
+
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
 
 isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
@@ -3752,6 +3770,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mkdirp@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
+  integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+
 moment-timezone@^0.5.28:
   version "0.5.28"
   resolved "https://registry.yarnpkg.com/moment-timezone/-/moment-timezone-0.5.28.tgz#f093d789d091ed7b055d82aa81a82467f72e4338"
@@ -3831,6 +3854,14 @@ node-releases@^1.1.29:
   resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.32.tgz#485b35c1bf9b4d8baa105d782f8ca731e518276e"
   dependencies:
     semver "^5.3.0"
+
+noms@0.0.0:
+  version "0.0.0"
+  resolved "https://registry.yarnpkg.com/noms/-/noms-0.0.0.tgz#da8ebd9f3af9d6760919b27d9cdc8092a7332859"
+  integrity sha1-2o69nzr51nYJGbJ9nNyAkqczKFk=
+  dependencies:
+    inherits "^2.0.1"
+    readable-stream "~1.0.31"
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -4287,7 +4318,7 @@ read-pkg@^2.0.0:
     normalize-package-data "^2.3.2"
     path-type "^2.0.0"
 
-readable-stream@^2.0.2:
+readable-stream@^2.0.2, readable-stream@~2.3.6:
   version "2.3.7"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.7.tgz#1eca1cf711aef814c04f62252a36a62f6cb23b57"
   integrity sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
@@ -4307,6 +4338,16 @@ readable-stream@^3.0.6:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
     util-deprecate "^1.0.1"
+
+readable-stream@~1.0.31:
+  version "1.0.34"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-1.0.34.tgz#125820e34bc842d2f2aaafafe4c2916ee32c157c"
+  integrity sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=
+  dependencies:
+    core-util-is "~1.0.0"
+    inherits "~2.0.1"
+    isarray "0.0.1"
+    string_decoder "~0.10.x"
 
 readdirp@^2.2.1:
   version "2.2.1"
@@ -4857,6 +4898,11 @@ string_decoder@^1.1.1:
   dependencies:
     safe-buffer "~5.2.0"
 
+string_decoder@~0.10.x:
+  version "0.10.31"
+  resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
+  integrity sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=
+
 string_decoder@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.1.1.tgz#9cf1611ba62685d7030ae9e4ba34149c3af03fc8"
@@ -4980,6 +5026,14 @@ throat@^5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/throat/-/throat-5.0.0.tgz#c5199235803aad18754a667d659b5e72ce16764b"
   integrity sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
+
+through2@^2.0.1:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/through2/-/through2-2.0.5.tgz#01c1e39eb31d07cb7d03a96a70823260b23132cd"
+  integrity sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==
+  dependencies:
+    readable-stream "~2.3.6"
+    xtend "~4.0.1"
 
 through@^2.3.6:
   version "2.3.8"
@@ -5153,6 +5207,11 @@ unset-value@^1.0.0:
   dependencies:
     has-value "^0.3.1"
     isobject "^3.0.0"
+
+untildify@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
+  integrity sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
 
 upath@^1.1.1:
   version "1.2.0"
@@ -5339,6 +5398,11 @@ xmlchars@^2.1.1:
 xmldom@^0.1.27:
   version "0.1.27"
   resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
+
+xtend@~4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/xtend/-/xtend-4.0.2.tgz#bb72779f5fa465186b1f438f674fa347fdb5db54"
+  integrity sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==
 
 y18n@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
Setup of build step and auto-publishing of bloom-contrib to npm.

While doing this I also updated all the references to the old northapp repository.

I tested this [locally](https://www.npmjs.com/package/@tmrow/bloom-contrib) and tried to set the right SSH key for GitHub pushes + npm token on CircleCI.

More context: https://github.com/tmrowco/bloom/pull/199#issuecomment-725263384 https://github.com/tmrowco/bloom/issues/217
