### PR TITLE
CI: Configure git user before releasing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,12 @@ jobs:
     steps:
       - attach_workspace:
           at: .
+      - run:
+          name: Configure git
+          command: |
+            git config --global user.email "kenneth.skovhus+bot@tmrow.com"
+            git config --global user.name "tmrow-bot"
+            git config --global push.default simple
       - run: bash scripts/release.sh
 
 


### PR DESCRIPTION
We are getting closer to releasing the package! 

Follow up on https://github.com/tmrowco/bloom-contrib/pull/482

https://support.circleci.com/hc/en-us/articles/360018860473-How-to-push-a-commit-back-to-the-same-repository-as-part-of-the-CircleCI-job