### PR TITLE
Setup GitHub workflows instead of CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,32 +34,9 @@ jobs:
           paths:
             - .
 
-  deploy:
-    docker:
-      - image: circleci/node:10.23
-    steps:
-      - attach_workspace:
-          at: .
-      - run:
-          name: Configure git
-          command: |
-            git config --global user.email "kenneth.skovhus+bot@tmrow.com"
-            git config --global user.name "tmrow-bot"
-            git config --global push.default simple
-      - run: bash scripts/release.sh
-
-
 workflows:
   version: 2
   main_workflow:
     jobs:
       - lint_yml
       - verify
-      - deploy:
-          requires:
-            - lint_yml
-            - verify
-          filters:
-            branches:
-              only:
-                - master

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,32 @@
+name: Deploy npm package
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile && cd playground && yarn --frozen-lockfile
+
+      - name: Configure git
+        run: |
+          git config --global user.email "kenneth.skovhus+bot@tmrow.com"
+          git config --global user.name "tmrow-bot"
+
+      - name: Verify changes and build
+        run: yarn verify:bail
+
+      - name: Deploy npm package
+        run: bash scripts/release.sh
+        env:
+          NPM_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -1,0 +1,30 @@
+name: Verify changes
+
+on: [pull_request]
+
+jobs:
+  ymllint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Install dependencies
+        run: pip install --user yamllint
+
+      - name: Lint yml files
+        run: yamllint co2eq/**/*.yml
+
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+
+      - name: Install dependencies
+        run: yarn --frozen-lockfile && cd playground && yarn --frozen-lockfile
+
+      - name: Verify changes and build
+        run: yarn verify:bail

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tmrow/bloom-contrib",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Carbon models and integrations used at Tomorrow",
   "license": "MIT",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,8 @@
     "build": "bash scripts/build.sh",
     "lint": "yarn lint:bail --fix --quiet",
     "lint:bail": "eslint *.js co2eq integrations playground",
-    "test": "TZ='Europe/Copenhagen' jest --no-cache"
+    "test": "TZ='Europe/Copenhagen' jest --no-cache",
+    "verify:bail": "yarn lint:bail && yarn test && yarn build"
   },
   "jest": {
     "clearMocks": true,


### PR DESCRIPTION
CircleCI is failing to verify GitHub's SSH key... This seems like a [known](https://discuss.circleci.com/t/the-authenticity-of-github-host-cant-be-stablished/33133) [problem](https://discuss.circleci.com/t/git-clone-fails-in-circle-2-0/15211) when trying to push to GitHub from CircleCI. I guess the SSH key should be updated?

Instead of spending more time on this, I suggest just using GitHub actions. It seems like a stable solution – and I've successfully used it for publishing packages in a [few](https://github.com/bash-lsp/bash-language-server) projects.