### PR TITLE
Supports multiplying by number of participants in meal model

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Activities require a certain formatting:
   departureStation, // (for other travel types) a string that represents the original starting point
   destinationStation, // (for other travel types) a string that represents the final destination
   participants, // (optional) the number of passengers (for car and motorbike travels)
+  isRoundtrip, // (optional) a boolean that represents whether this trip was a round/return trip
 }
 ```
 
@@ -214,6 +215,7 @@ Activities require a certain formatting:
   activityType: ACTIVITY_TYPE_MEAL,
   lineItems, // (required if the activity contains ingredients) an array with an object [{ identifier: xx, value: 2.1, unit: 'kg'}] where `identifier` is a key from footprints.yml and `unit` a valid unit from definitions.js
   mealType, // (required if the activity is a meal type) a string with the value being one of the meal type options in definitions.js
+  numberOfMeals, // the amount of meals that this activity covers
 }
 ```
 

--- a/co2eq/food/meal.js
+++ b/co2eq/food/meal.js
@@ -12,7 +12,7 @@ const MEALS_PER_DAY = 3;
 
 // ** modelName must not be changed. If changed then old activities will not be re-calculated **
 export const modelName = 'meal';
-export const modelVersion = '6';
+export const modelVersion = '7';
 export const explanation = {
   text:
     'The calculations take into consideration greenhouse gas emissions across the whole lifecycle for an average meal of a specific diet.',
@@ -61,13 +61,19 @@ function carbonIntensityOfMealType(mealType) {
 Carbon emissions of an activity (in kgCO2eq)
 */
 export function carbonEmissions(activity) {
-  const { mealType } = activity;
+  const { mealType, participants } = activity;
 
-  if (mealType) {
-    return carbonIntensityOfMealType(mealType);
+  if (!mealType) {
+    throw new Error(
+      "Couldn't calculate carbonEmissions for activity because it does not have any ingredients or meal type"
+    );
   }
 
-  throw new Error(
-    "Couldn't calculate carbonEmissions for activity because it does not have any ingredients or meal type"
-  );
+  const footprint = carbonIntensityOfMealType(mealType);
+
+  if (!participants || participants < 0) {
+    return footprint;
+  }
+
+  return footprint * participants;
 }

--- a/co2eq/food/meal.js
+++ b/co2eq/food/meal.js
@@ -61,7 +61,7 @@ function carbonIntensityOfMealType(mealType) {
 Carbon emissions of an activity (in kgCO2eq)
 */
 export function carbonEmissions(activity) {
-  const { mealType, participants } = activity;
+  const { mealType, numberOfMeals } = activity;
 
   if (!mealType) {
     throw new Error(
@@ -71,9 +71,9 @@ export function carbonEmissions(activity) {
 
   const footprint = carbonIntensityOfMealType(mealType);
 
-  if (!participants || participants < 0) {
+  if (!numberOfMeals || numberOfMeals < 0) {
     return footprint;
   }
 
-  return footprint * participants;
+  return footprint * numberOfMeals;
 }

--- a/co2eq/food/meal.test.js
+++ b/co2eq/food/meal.test.js
@@ -22,35 +22,35 @@ describe('model runs', () => {
     expect(() => carbonEmissions(activity)).toThrowError('Unknown meal type: not-real');
   });
 
-  it('multiplies emissions by number of participants', () => {
+  it('multiplies emissions by number of numberOfMeals', () => {
     const activity = {
       activityType: ACTIVITY_TYPE_MEAL,
       mealType: MEAL_TYPE_PESCETARIAN,
-      participants: 3,
+      numberOfMeals: 3,
     };
 
     expect(modelCanRun(activity)).toBeTruthy();
     expect(carbonEmissions(activity)).toBeCloseTo(1.303 * 3);
   });
 
-  it('ignores invalid number of participants', () => {
+  it('ignores invalid number of numberOfMeals', () => {
     const baseActivity = {
       activityType: ACTIVITY_TYPE_MEAL,
       mealType: MEAL_TYPE_PESCETARIAN,
     };
-    const activityWithNegativeParticipants = {
+    const activityWithNegativeNumberOfMeals = {
       ...baseActivity,
-      participants: -1,
+      numberOfMeals: -1,
     };
-    const activityWithZeroParticipants = {
+    const activityWithZeroNumberOfMeals = {
       ...baseActivity,
-      participants: 0,
+      numberOfMeals: 0,
     };
 
-    expect(modelCanRun(activityWithNegativeParticipants)).toBeTruthy();
-    expect(carbonEmissions(activityWithNegativeParticipants)).toBeCloseTo(1.303);
+    expect(modelCanRun(activityWithNegativeNumberOfMeals)).toBeTruthy();
+    expect(carbonEmissions(activityWithNegativeNumberOfMeals)).toBeCloseTo(1.303);
 
-    expect(modelCanRun(activityWithZeroParticipants)).toBeTruthy();
-    expect(carbonEmissions(activityWithZeroParticipants)).toBeCloseTo(1.303);
+    expect(modelCanRun(activityWithZeroNumberOfMeals)).toBeTruthy();
+    expect(carbonEmissions(activityWithZeroNumberOfMeals)).toBeCloseTo(1.303);
   });
 });

--- a/co2eq/food/meal.test.js
+++ b/co2eq/food/meal.test.js
@@ -21,4 +21,36 @@ describe('model runs', () => {
     expect(modelCanRun(activity)).toBeTruthy();
     expect(() => carbonEmissions(activity)).toThrowError('Unknown meal type: not-real');
   });
+
+  it('multiplies emissions by number of participants', () => {
+    const activity = {
+      activityType: ACTIVITY_TYPE_MEAL,
+      mealType: MEAL_TYPE_PESCETARIAN,
+      participants: 3,
+    };
+
+    expect(modelCanRun(activity)).toBeTruthy();
+    expect(carbonEmissions(activity)).toBeCloseTo(1.303 * 3);
+  });
+
+  it('ignores invalid number of participants', () => {
+    const baseActivity = {
+      activityType: ACTIVITY_TYPE_MEAL,
+      mealType: MEAL_TYPE_PESCETARIAN,
+    };
+    const activityWithNegativeParticipants = {
+      ...baseActivity,
+      participants: -1,
+    };
+    const activityWithZeroParticipants = {
+      ...baseActivity,
+      participants: 0,
+    };
+
+    expect(modelCanRun(activityWithNegativeParticipants)).toBeTruthy();
+    expect(carbonEmissions(activityWithNegativeParticipants)).toBeCloseTo(1.303);
+
+    expect(modelCanRun(activityWithZeroParticipants)).toBeTruthy();
+    expect(carbonEmissions(activityWithZeroParticipants)).toBeCloseTo(1.303);
+  });
 });

--- a/co2eq/food/meal.test.js
+++ b/co2eq/food/meal.test.js
@@ -1,0 +1,24 @@
+import { ACTIVITY_TYPE_MEAL, MEAL_TYPE_PESCETARIAN } from '../../definitions';
+import { carbonEmissions, modelCanRun } from './meal';
+
+describe('model runs', () => {
+  it('calculates based on meal type', () => {
+    const activity = {
+      activityType: ACTIVITY_TYPE_MEAL,
+      mealType: MEAL_TYPE_PESCETARIAN,
+    };
+
+    expect(modelCanRun(activity)).toBeTruthy();
+    expect(carbonEmissions(activity)).toBeCloseTo(1.303);
+  });
+
+  it('throws on non existing meal type', () => {
+    const activity = {
+      activityType: ACTIVITY_TYPE_MEAL,
+      mealType: 'not-real',
+    };
+
+    expect(modelCanRun(activity)).toBeTruthy();
+    expect(() => carbonEmissions(activity)).toThrowError('Unknown meal type: not-real');
+  });
+});


### PR DESCRIPTION
## Issue

https://github.com/tmrowco/bloom/issues/338

## Description

Updates **Meal** model to support multiplying the emission by number of meals/participants.


### Changes

- Wrote tests to cover existing model
- Added new functionality
- Bumped model version

### Preview

![image](https://user-images.githubusercontent.com/3296643/100743473-9c1e8680-33dc-11eb-95e6-e0136d9cdd8f.png)


### :warning: FYI/NOTE

I am not sure about best approach here with regards to name - I have here reused `participants` from `transportation`, but would it make more sense to have something like "numberOfMeals" instead? 🤔 

I'm unsure if it's too weird that `participants` is **multiplying** emissions here, but **dividing** emissions in the transportation model.