### PR TITLE
Less greedy modelCanRun for ingredients model

### DIFF
--- a/co2eq/food/ingredients.js
+++ b/co2eq/food/ingredients.js
@@ -7,7 +7,7 @@ import {
 } from '../purchase';
 
 export const modelName = 'meal-from-ingredients';
-export const modelVersion = `1_${getChecksumOfFootprints()}`;
+export const modelVersion = `2_${getChecksumOfFootprints()}`;
 export const explanation = {
   text:
     'The calculations take into consideration emissions of greenhouse gases across the whole lifecycle of the ingredients.',

--- a/co2eq/food/ingredients.js
+++ b/co2eq/food/ingredients.js
@@ -23,6 +23,17 @@ export const modelCanRunVersion = 1;
 export function modelCanRun(activity) {
   const { activityType, lineItems } = activity;
   if (activityType === ACTIVITY_TYPE_MEAL && lineItems && lineItems.length) {
+    const { identifier } = lineItems[0];
+    const entry = getEntryByKey(identifier);
+    if (!entry) {
+      return false;
+    }
+    if (!entry.intensityKilograms) {
+      return false;
+    }
+    if (entry.unit !== UNIT_KILOGRAMS) {
+      return false;
+    }
     return true;
   }
   return false;

--- a/co2eq/food/ingredients.js
+++ b/co2eq/food/ingredients.js
@@ -7,7 +7,7 @@ import {
 } from '../purchase';
 
 export const modelName = 'meal-from-ingredients';
-export const modelVersion = `2_${getChecksumOfFootprints()}`;
+export const modelVersion = `1_${getChecksumOfFootprints()}`;
 export const explanation = {
   text:
     'The calculations take into consideration emissions of greenhouse gases across the whole lifecycle of the ingredients.',
@@ -19,7 +19,7 @@ export const explanation = {
   ],
 };
 
-export const modelCanRunVersion = 1;
+export const modelCanRunVersion = 2;
 export function modelCanRun(activity) {
   const { activityType, lineItems } = activity;
   if (activityType === ACTIVITY_TYPE_MEAL && lineItems && lineItems.length) {


### PR DESCRIPTION
https://github.com/tmrowco/bloom/issues/404

Adjust `modelCanRun` for ingredients model to not be as greedy. 

To me this shows that we need a better way of annotating the supported types and how to not duplicate `modelCanRun` and the validation done in the model. 

I suggest we investigate https://github.com/colinhacks/zod or https://github.com/pelotom/runtypes